### PR TITLE
Add Token Validation From Link Form

### DIFF
--- a/UnivaPay-for-WooCommerce/UnivaPay-for-WooCommerce.php
+++ b/UnivaPay-for-WooCommerce/UnivaPay-for-WooCommerce.php
@@ -26,6 +26,7 @@ function univapay_init_gateway_class()
         return;
     }
 
+    require_once plugin_dir_path(__FILE__) . 'includes/WC-Univapay-Constants.php';
     require_once plugin_dir_path(__FILE__) . 'includes/WC-Univapay-Gateway.php';
 
     add_filter('woocommerce_payment_gateways', 'univapay_add_gateway_class');

--- a/UnivaPay-for-WooCommerce/UnivaPay-for-WooCommerce.php
+++ b/UnivaPay-for-WooCommerce/UnivaPay-for-WooCommerce.php
@@ -45,6 +45,9 @@ function univapay_init_gateway_class()
     function add_custom_boxes()
     {
         global $post;
+        if (empty($post)) {
+            return;
+        }
         $paymentMethod = get_post_meta($post->ID, '_payment_method');
         if (empty($paymentMethod) || $paymentMethod[0] !== 'upfw') {
             return;

--- a/UnivaPay-for-WooCommerce/build/block_checkout.js
+++ b/UnivaPay-for-WooCommerce/build/block_checkout.js
@@ -73,6 +73,7 @@ const Content = (props) => {
             'data-currency': params.currency,
             'data-inline': true,
             'data-inline-item-style': 'padding: 0 2px',
+            'data-metadata': 'order_id:' + params.order_id,
         }).appendTo("#upfw_checkout");
         
         if(params.formUrl !== '') {
@@ -117,6 +118,7 @@ const Content = (props) => {
             capture: settings.capture,
             currency: settings.currency,
             formUrl: settings.formUrl,
+            order_id: settings.order_id,
         };
 
         const isUnivapayGatewaySelected = () => {

--- a/UnivaPay-for-WooCommerce/build/block_checkout.js
+++ b/UnivaPay-for-WooCommerce/build/block_checkout.js
@@ -99,13 +99,17 @@ const Content = (props) => {
             v.parentNode.removeChild(v);
         });
         var iFrame = document.querySelector("#upfw_checkout iframe");
+        
+        showLoadingSpinner();
         UnivapayCheckout.submit(iFrame)
             .then((res) => {
+                hideLoadingSpinner();
                 univapayOptionalRef.current = 'false';
                 univapayChargeIdRef.current = res.charge;
                 getPalaceOrderButton().click();
             })
             .catch((errors) => {
+                hideLoadingSpinner();
                 alert("入力内容をご確認ください");
                 console.error(errors);
             });
@@ -157,6 +161,44 @@ const Content = (props) => {
     return decodeEntities(settings.description || '');
 };
 
+// Add the loading spinner HTML to the body
+document.body.insertAdjacentHTML('beforeend', `
+    <div id="loading-spinner" style="display: none;">
+        <div class="spinner"></div>
+    </div>
+`);
+
+// Add the CSS for the loading spinner
+const style = document.createElement('style');
+style.innerHTML = `
+    #loading-spinner {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(255, 255, 255, 0.8);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 9999;
+    }
+
+    .spinner {
+        border: 4px solid rgba(0, 0, 0, 0.1);
+        border-left-color: #000;
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
+    }
+`;
+document.head.appendChild(style);
+
 /**
  * Univapay payment method config object.
  */
@@ -173,3 +215,11 @@ const UnivaPay = {
 };
 
 registerPaymentMethod( UnivaPay );
+
+function showLoadingSpinner() {
+    document.getElementById('loading-spinner').style.display = 'flex';
+}
+
+function hideLoadingSpinner() {
+    document.getElementById('loading-spinner').style.display = 'none';
+}

--- a/UnivaPay-for-WooCommerce/build/block_checkout.js
+++ b/UnivaPay-for-WooCommerce/build/block_checkout.js
@@ -29,23 +29,15 @@ const Content = (props) => {
 
     const fetchSettings = async () => {
         try {
-            const response = await jQuery.ajax({
-                url: '/wp-admin/admin-ajax.php',
-                method: 'POST',
-                data: {
-                    action: 'get_univapay_settings',
-                }
-            })
-            if (response.success) {
-                setSettings(response.data);
-            } else {
-                alert('UnivaPayの設定の取得に失敗しました。後ほど再度お試しください。');
-                console.error('Error fetching settings:', response);
+            const response = await fetch('/index.php?rest_route=/univapay/v1/settings');
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
             }
-
+            const data = await response.json();
+            setSettings(data);
         } catch (error) {
-            alert('予期しないエラーが発生しました。後ほど再度お試しください。');
-            console.error('Error fetching settings:', error);
+            console.error('設定の取得中にエラーが発生しました:', error);
+            alert('予期しないエラーが発生しました。後ほど再試行してください。');
         }
     };
 
@@ -84,7 +76,7 @@ const Content = (props) => {
         );
     
         jQuery('<span></span>').attr({
-            'data-app-id': settings.token,
+            'data-app-id': settings.app_id,
             'data-checkout': "payment",
             'data-email': getEmail(),
             'data-amount': totalOrder, 

--- a/UnivaPay-for-WooCommerce/build/block_checkout.js
+++ b/UnivaPay-for-WooCommerce/build/block_checkout.js
@@ -4,12 +4,13 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { getSetting } from '@woocommerce/settings';
 import { useEffect, useRef } from 'react';
 import { useSelect } from '@wordpress/data';
+import './univapay.css';
 
 const settings = getSetting( 'upfw_data', {} );
 
 const defaultLabel = __(
-	'UnivaPay',
-	'woo-gutenberg-products-block'
+    'UnivaPay',
+    'woo-gutenberg-products-block'
 );
 
 const label = decodeEntities( settings.title ) || defaultLabel;
@@ -20,8 +21,8 @@ const label = decodeEntities( settings.title ) || defaultLabel;
  * @param {*} props Props from payment API.
  */
 const Label = ( props ) => {
-	const { PaymentMethodLabel } = props.components;
-	return <PaymentMethodLabel text={ label } />;
+    const { PaymentMethodLabel } = props.components;
+    return <PaymentMethodLabel text={ label } />;
 };
 
 const Content = (props) => {
@@ -117,7 +118,7 @@ const Content = (props) => {
     
     useEffect(() => {
         const params = {
-			appId: settings.token,
+            appId: settings.token,
             checkout: 'payment',
             capture: settings.capture,
             currency: settings.currency,
@@ -168,50 +169,19 @@ document.body.insertAdjacentHTML('beforeend', `
     </div>
 `);
 
-// Add the CSS for the loading spinner
-const style = document.createElement('style');
-style.innerHTML = `
-    #loading-spinner {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(255, 255, 255, 0.8);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 9999;
-    }
-
-    .spinner {
-        border: 4px solid rgba(0, 0, 0, 0.1);
-        border-left-color: #000;
-        border-radius: 50%;
-        width: 40px;
-        height: 40px;
-        animation: spin 1s linear infinite;
-    }
-
-    @keyframes spin {
-        to { transform: rotate(360deg); }
-    }
-`;
-document.head.appendChild(style);
-
 /**
  * Univapay payment method config object.
  */
 const UnivaPay = {
-	name: "upfw",
-	label: <Label />,
-	content: <Content />,
-	edit: <Content />,
-	canMakePayment: () => true,
-	ariaLabel: label,
-	supports: {
-		features: settings.supports,
-	}
+    name: "upfw",
+    label: <Label />,
+    content: <Content />,
+    edit: <Content />,
+    canMakePayment: () => true,
+    ariaLabel: label,
+    supports: {
+        features: settings.supports,
+    }
 };
 
 registerPaymentMethod( UnivaPay );

--- a/UnivaPay-for-WooCommerce/build/univapay.css
+++ b/UnivaPay-for-WooCommerce/build/univapay.css
@@ -1,0 +1,25 @@
+#loading-spinner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.spinner {
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-left-color: #000;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}

--- a/UnivaPay-for-WooCommerce/build/univapay.js
+++ b/UnivaPay-for-WooCommerce/build/univapay.js
@@ -37,9 +37,10 @@ function render() {
         'data-checkout': "payment",
         'data-email': getEmail(),
         'data-amount': univapay_params.total,
-        'data-capture': univapay_params.capture ? 'true' : 'false',
+        'data-capture': univapay_params.capture,
         'data-currency': univapay_params.currency,
         'data-inline': true,
+        'data-metadata': 'order_id:' + univapay_params.order_id,
         'data-inline-item-style': 'padding: 0 2px',
     }).appendTo("#upfw_checkout");
     jQuery("#place_order").after(
@@ -87,6 +88,8 @@ function payfororder(e) {
         amount: univapay_params.total,
         capture: univapay_params.capture,
         currency: univapay_params.currency,
+        inline: true,
+        metadata: 'order_id:' + univapay_params.order_id,
         onSuccess: (result) => {
             jQuery('<input>').attr({
                 'type': 'hidden',

--- a/UnivaPay-for-WooCommerce/build/univapay.js
+++ b/UnivaPay-for-WooCommerce/build/univapay.js
@@ -14,10 +14,11 @@ function hideLoadingSpinner() {
 
 function doCheckout() {
     // clear before token
-    document.querySelectorAll('[name="univapayTokenId"]').forEach(function(v) {
+    document.querySelectorAll('[name="univapayChargeId"]').forEach(function(v) {
         v.parentNode.removeChild(v);
     });
     var iFrame = document.querySelector("#upfw_checkout iframe");
+
     showLoadingSpinner();
     UnivapayCheckout.submit(iFrame)
         .then(() => {
@@ -48,7 +49,7 @@ function render() {
             'id': 'upfw_checkout'
     }));
     jQuery('<span></span>').attr({
-        'data-app-id': univapay_params.token,
+        'data-app-id': univapay_params.app_id,
         'data-checkout': "payment",
         'data-email': getEmail(),
         'data-amount': univapay_params.total,
@@ -106,7 +107,7 @@ function payfororder(e) {
         return;
     e.preventDefault();
     var checkout = UnivapayCheckout.create({
-        appId: univapay_params.token,
+        appId: univapay_params.app_id,
         checkout: 'payment',
         email: univapay_params.email,
         amount: univapay_params.total,

--- a/UnivaPay-for-WooCommerce/build/univapay.js
+++ b/UnivaPay-for-WooCommerce/build/univapay.js
@@ -1,3 +1,5 @@
+import './univapay.css'
+
 function selected() {
     return jQuery('#payment_method_upfw').prop('checked');
 }
@@ -87,37 +89,6 @@ document.body.insertAdjacentHTML('beforeend', `
     </div>
 `);
 
-// Add the CSS for the loading spinner
-const style = document.createElement('style');
-style.innerHTML = `
-    #loading-spinner {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(255, 255, 255, 0.8);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 9999;
-    }
-
-    .spinner {
-        border: 4px solid rgba(0, 0, 0, 0.1);
-        border-left-color: #000;
-        border-radius: 50%;
-        width: 40px;
-        height: 40px;
-        animation: spin 1s linear infinite;
-    }
-
-    @keyframes spin {
-        to { transform: rotate(360deg); }
-    }
-`;
-document.head.appendChild(style);
-
 function checkSelect() {
     jQuery("#place_order").hide();
     jQuery("#upfw_checkout").remove();
@@ -129,6 +100,7 @@ function checkSelect() {
         jQuery("#place_order").show();
     }
 }
+
 function payfororder(e) {
     if(!selected())
         return;
@@ -163,6 +135,7 @@ function payfororder(e) {
     });
     checkout.open();
 }
+
 jQuery(document).ready(function($) {
     $(document.body).on("updated_checkout payment_method_selected", checkSelect);
     $('#order_review').on("submit", payfororder);

--- a/UnivaPay-for-WooCommerce/build/univapay.js
+++ b/UnivaPay-for-WooCommerce/build/univapay.js
@@ -1,21 +1,34 @@
 function selected() {
     return jQuery('#payment_method_upfw').prop('checked');
 }
+
+function showLoadingSpinner() {
+    document.getElementById('loading-spinner').style.display = 'flex';
+}
+
+function hideLoadingSpinner() {
+    document.getElementById('loading-spinner').style.display = 'none';
+}
+
 function doCheckout() {
     // clear before token
     document.querySelectorAll('[name="univapayTokenId"]').forEach(function(v) {
         v.parentNode.removeChild(v);
     });
     var iFrame = document.querySelector("#upfw_checkout iframe");
+    showLoadingSpinner();
     UnivapayCheckout.submit(iFrame)
         .then(() => {
+            hideLoadingSpinner();
             document.querySelector('#place_order').click();
         })
         .catch((errors) => {
+            hideLoadingSpinner();
             alert("入力内容をご確認ください");
             console.error(errors);
         });
 }
+
 function optional() {
     jQuery('<input>').attr({
         'type': 'hidden',
@@ -66,6 +79,45 @@ function render() {
             }).on("click", optional));
     }
 }
+
+// Add the loading spinner HTML to the body
+document.body.insertAdjacentHTML('beforeend', `
+    <div id="loading-spinner" style="display: none;">
+        <div class="spinner"></div>
+    </div>
+`);
+
+// Add the CSS for the loading spinner
+const style = document.createElement('style');
+style.innerHTML = `
+    #loading-spinner {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(255, 255, 255, 0.8);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 9999;
+    }
+
+    .spinner {
+        border: 4px solid rgba(0, 0, 0, 0.1);
+        border-left-color: #000;
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
+    }
+`;
+document.head.appendChild(style);
+
 function checkSelect() {
     jQuery("#place_order").hide();
     jQuery("#upfw_checkout").remove();

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Constants.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Constants.php
@@ -1,0 +1,13 @@
+<?php
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+class WC_Univapay_Constants
+{
+    // WooCommerce related
+    public const CHECKOUT_DRAFT_STATUS = 'checkout-draft';
+    public const SESSION_ORDER_DRAFT_ID = 'draft_order_id';
+    public const ORDER_AWAITING_PAYMENT = 'order_awaiting_payment';
+}

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway-Blocks-Support.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway-Blocks-Support.php
@@ -47,6 +47,9 @@ final class WC_Univapay_Gateway_Blocks_Support extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
+		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ?
+            absint( WC()->session->order_awaiting_payment ) : absint( WC()->session->get( 'store_api_draft_order', 0 ) );
+
         // NOTE: Avoid using the cart's order price for the widget
         // as it may change during the checkout process (e.g., due to coupons)
         return [
@@ -57,6 +60,7 @@ final class WC_Univapay_Gateway_Blocks_Support extends AbstractPaymentMethodType
             'capture' => $this->gateway->capture === 'yes',
             'currency' => strtolower(get_woocommerce_currency()),
             'formUrl' => $this->gateway->formurl,
+            'order_id' => $current_session_order_id,
         ];
     }
 }

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway-Blocks-Support.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway-Blocks-Support.php
@@ -47,10 +47,15 @@ final class WC_Univapay_Gateway_Blocks_Support extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
-		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ?
-            absint( WC()->session->order_awaiting_payment ) : absint( WC()->session->get( 'store_api_draft_order', 0 ) );
+        $current_session_order_id = 0;
 
-        // NOTE: Avoid using the cart's order price for the widget
+        // no session available, when opening site editor on admin page
+        if (WC()->session) {
+            $current_session_order_id = isset(WC()->session->order_awaiting_payment) ?
+                absint(WC()->session->order_awaiting_payment) : absint(WC()->session->get('store_api_draft_order', 0));
+        }
+
+        // Avoid using the cart's order price into payment information
         // as it may change during the checkout process (e.g., due to coupons)
         return [
             'title' => $this->gateway->get_title(),

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
@@ -249,6 +249,10 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
 
         $money = new Money($order->get_data()["total"], new Currency($order->get_data()["currency"]));
         if (isset($_POST['univapay_optional']) && $_POST['univapay_optional'] === 'true') {
+            $metadata = array(
+                'order_id' => $order_id
+            );
+
             return array(
                 'result' => 'success',
                 'redirect' => $this->formurl .
@@ -259,6 +263,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
                     '&auth=' . ($capture ? 'false' : 'true') . # auth: true = authorize, false = capture
                     '&amount=' . $money->getAmount() .
                     '&currency=' . $money->getCurrency() .
+                    '&metadata=' . json_encode($metadata) .
                     '&successRedirectUrl=' . urlencode($this->get_return_url($order)) .
                     '&failureRedirectUrl=' . urlencode($this->get_return_url($order)) .
                     '&pendingRedirectUrl=' . urlencode($this->get_return_url($order))

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
@@ -244,7 +244,8 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
      * Use draft order if exists
      * @param WC_Order $order
      */
-    function use_draft_order_if_exists($order) {
+    function use_draft_order_if_exists($order)
+    {
         $draft_order_id = WC()->session->get(WC_Univapay_Constants::SESSION_ORDER_DRAFT_ID);
         if ($draft_order_id) {
             $existing_order = wc_get_order($draft_order_id);
@@ -285,7 +286,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
             $univapay_asset_file['version'],
             true
         );
-        $order_id = WC()->session->get(WC_Univapay_Constants::ORDER_AWAITING_PAYMENT) ? 
+        $order_id = WC()->session->get(WC_Univapay_Constants::ORDER_AWAITING_PAYMENT) ?
             WC()->session->get(WC_Univapay_Constants::ORDER_AWAITING_PAYMENT) : WC()->session->get(WC_Univapay_Constants::SESSION_ORDER_DRAFT_ID);
         $order = wc_get_order($order_id);
 
@@ -293,7 +294,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
             'token' => $this->token,
             'formurl' => $this->formurl,
             'total' => $order ? $order->get_total() : WC()->cart->total,
-            'capture' => ($this->capture === 'yes') ? "true" : "false",
+            'capture' => ($this->capture === 'yes') ? 'true' : 'false',
             'currency' => strtolower(get_woocommerce_currency()),
             'email' => $order ? $order->get_billing_email() : null,
             'order_id' => $order ? $order->get_id() : null,
@@ -383,7 +384,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
                 $this->univapay_client = new UnivapayClient($token, $this->univapay_client_options);
             }
             $charge = $this->univapay_client->getCharge($token->storeId, $_GET['univapayChargeId']);
-            
+
             if (!_is_charge_valid($charge, $order)) {
                 wc_add_notice(__('決済エラー入力内容を確認してください', 'upfw') . $charge->error["details"], 'error');
                 wp_safe_redirect(wc_get_checkout_url());
@@ -433,11 +434,11 @@ function _is_charge_valid($charge, $order)
     if ($charge->error) {
         return false;
     }
-    // if (!isset($charge->metadata['order_id'])) {
-    //     return false;
-    // }
-    // if ($charge->metadata['order_id'] !== $order->get_id()) {
-    //     return false;
-    // }
+    if (!isset($charge->metadata['order_id'])) {
+        return false;
+    }
+    if ((int) $charge->metadata['order_id'] !== $order->get_id()) {
+        return false;
+    }
     return true;
 }

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
@@ -281,7 +281,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
             'token' => $this->token,
             'formurl' => $this->formurl,
             'total' => $order ? $order->get_total() : WC()->cart->total,
-            'capture' => ($this->capture === 'yes') ? true : false, // boolean on frontend
+            'capture' => ($this->capture === 'yes') ? "true" : "false",
             'currency' => strtolower(get_woocommerce_currency()),
             'email' => $order ? $order->get_billing_email() : null,
             'order_id' => $order ? $order->get_id() : null,

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
@@ -120,6 +120,18 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
         // TODO: only enqueue scripts on neccessary pages (e.g: checkout, myaccount-oders)
         add_action('wp_enqueue_scripts', array($this, 'payment_scripts'));
         add_action('woocommerce_thankyou', array($this, 'process_order_completion'));
+
+        // Display charge id in order details
+        // TODO: fix meta box later and see what we can do with this
+        add_action('woocommerce_admin_order_data_after_order_details', function ($order) {
+            $order_id = method_exists($order, 'get_id') ? $order->get_id() : $order->id;
+            $univapay_charge_id = get_post_meta($order_id, 'univapayChargeId', true);
+            if ($univapay_charge_id) {
+                echo '<div class="form-field form-field-wide">';
+                echo '<p><strong>' . __('課金ID') . ':</strong> ' . $univapay_charge_id . '</p>';
+                echo '</div>';
+            }
+        });
     }
 
     /**

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
@@ -291,7 +291,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
         $order = wc_get_order($order_id);
 
         wp_localize_script('univapay_woocommerce', 'univapay_params', array(
-            'token' => $this->token,
+            'app_id' => $this->token,
             'formurl' => $this->formurl,
             'total' => $order ? $order->get_total() : WC()->cart->total,
             'capture' => ($this->capture === 'yes') ? 'true' : 'false',

--- a/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
+++ b/UnivaPay-for-WooCommerce/includes/WC-Univapay-Gateway.php
@@ -374,7 +374,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
     public function process_order_completion()
     {
         // TODO: add handling process for failure or pending?
-        if (!is_order_received_page() || empty($_GET['univapayChargeId'])) {
+        if (empty($_GET['univapayChargeId'])) {
             wc_add_notice('決済エラーサイト管理者にお問い合わせください。', 'error');
             wp_safe_redirect(wc_get_checkout_url());
             exit;
@@ -405,7 +405,7 @@ class WC_Univapay_Gateway extends WC_Payment_Gateway
                 // add comment for order can see admin panel
                 $order->add_order_note(__('UnivaPayでの支払が完了いたしました。', 'upfw'), true);
             } else {
-                $order->update_status('on-hold', __('キャプチャ待ちです', 'upfw'));
+                $order->update_status($this->status, __('キャプチャ待ちです', 'upfw'));
                 // add comment for order can see admin panel
                 $order->add_order_note(__('UnivaPayでのオーソリが完了いたしました。', 'upfw'), true);
             }

--- a/UnivaPay-for-WooCommerce/package-lock.json
+++ b/UnivaPay-for-WooCommerce/package-lock.json
@@ -8,7 +8,10 @@
         "@woocommerce/dependency-extraction-webpack-plugin": "^3.0.1",
         "@woocommerce/settings": "^1.0.0",
         "@wordpress/scripts": "^28.4.0",
+        "css-loader": "^7.1.2",
         "glob": "^11.0.0",
+        "mini-css-extract-plugin": "^2.9.1",
+        "style-loader": "^4.0.0",
         "webpack": "^5.93.0"
       }
     },
@@ -4650,11 +4653,60 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/@wordpress/scripts/node_modules/css-loader": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
+      "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.33",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/scripts/node_modules/json2php": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.7.tgz",
       "integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
       "dev": true
+    },
+    "node_modules/@wordpress/scripts/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@wordpress/stylelint-config": {
       "version": "22.5.0",
@@ -6599,10 +6651,11 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
-      "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
+      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
         "postcss": "^8.4.33",
@@ -6614,7 +6667,7 @@
         "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6622,7 +6675,7 @@
       },
       "peerDependencies": {
         "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.0.0"
+        "webpack": "^5.27.0"
       },
       "peerDependenciesMeta": {
         "@rspack/core": {
@@ -12966,10 +13019,11 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
-      "integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
+      "integrity": "sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0",
         "tapable": "^2.2.1"
@@ -16997,6 +17051,23 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
       }
     },
     "node_modules/style-search": {
@@ -22554,10 +22625,32 @@
             "json2php": "^0.0.7"
           }
         },
+        "css-loader": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
+          "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.1.0",
+            "postcss": "^8.4.33",
+            "postcss-modules-extract-imports": "^3.1.0",
+            "postcss-modules-local-by-default": "^4.0.5",
+            "postcss-modules-scope": "^3.2.0",
+            "postcss-modules-values": "^4.0.0",
+            "postcss-value-parser": "^4.2.0",
+            "semver": "^7.5.4"
+          }
+        },
         "json2php": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.7.tgz",
           "integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         }
       }
@@ -24001,9 +24094,9 @@
       "dev": true
     },
     "css-loader": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
-      "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
+      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
       "dev": true,
       "requires": {
         "icss-utils": "^5.1.0",
@@ -28719,9 +28812,9 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
-      "integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
+      "integrity": "sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==",
       "dev": true,
       "requires": {
         "schema-utils": "^4.0.0",
@@ -31656,6 +31749,13 @@
           "dev": true
         }
       }
+    },
+    "style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "dev": true,
+      "requires": {}
     },
     "style-search": {
       "version": "0.1.0",

--- a/UnivaPay-for-WooCommerce/package.json
+++ b/UnivaPay-for-WooCommerce/package.json
@@ -1,14 +1,17 @@
 {
   "scripts": {
-    "build": "wp-scripts build",
-    "packages-update": "wp-scripts packages-update",
-    "start": "webpack serve --config webpack.config.js"
+    "build": "wp-scripts build --config webpack.config.js --mode production",
+    "start": "wp-scripts start --config webpack.config.js --mode development",
+    "packages-update": "wp-scripts packages-update"
   },
   "devDependencies": {
     "@woocommerce/dependency-extraction-webpack-plugin": "^3.0.1",
     "@woocommerce/settings": "^1.0.0",
     "@wordpress/scripts": "^28.4.0",
+    "css-loader": "^7.1.2",
     "glob": "^11.0.0",
+    "mini-css-extract-plugin": "^2.9.1",
+    "style-loader": "^4.0.0",
     "webpack": "^5.93.0"
   }
 }

--- a/UnivaPay-for-WooCommerce/tests/base-plugin-test.php
+++ b/UnivaPay-for-WooCommerce/tests/base-plugin-test.php
@@ -51,11 +51,12 @@ class BasePluginTest extends WP_UnitTestCase
     {
         $payment_gateways = WC()->payment_gateways()->payment_gateways();
         $payment_gateways['upfw'] = new WC_Univapay_Gateway();
-        $payment_gateways['upfw']->token = "mock_app_token";
+        $payment_gateways['upfw']->token = $this->faker->uuid;
+        $payment_gateways['upfw']->secret = $this->faker->uuid;
         $payment_gateways['upfw']->capture = 'yes';
         $payment_gateways['upfw']->formurl = 'http://test.localhost';
         $payment_gateways['upfw']->enabled = 'yes';
-        $payment_gateways['upfw']->status = 'processing';
+        $payment_gateways['upfw']->status = 'pending-payment';
 
         return $payment_gateways;
     }

--- a/UnivaPay-for-WooCommerce/tests/base-plugin-test.php
+++ b/UnivaPay-for-WooCommerce/tests/base-plugin-test.php
@@ -93,6 +93,7 @@ class BasePluginTest extends WP_UnitTestCase
         $order->set_billing_address_1($this->faker->streetAddress);
         $order->set_billing_city($this->faker->city);
         $order->set_billing_postcode($this->faker->postcode);
+        $order->set_billing_phone($this->faker->phoneNumber);
         $order->set_billing_country('JP');
         $order->set_currency('JPY');
         $order->save();

--- a/UnivaPay-for-WooCommerce/tests/test-payment-processing.php
+++ b/UnivaPay-for-WooCommerce/tests/test-payment-processing.php
@@ -13,9 +13,6 @@ class TestPaymentProcessing extends BasePluginTest
         $_POST['univapay_optional'] = 'true';
         $result = $this->payment_gateways['upfw']->process_payment($order->get_id());
         $money = new Money($order->get_data()["total"], new Currency($order->get_data()["currency"]));
-        $metatag = array(
-            'order_id' => $order->get_id(),
-        );
 
         $expectedRedirectUrl = $this->payment_gateways['upfw']->formurl .
             '?appId=' . $this->payment_gateways['upfw']->token .
@@ -25,7 +22,7 @@ class TestPaymentProcessing extends BasePluginTest
             '&auth=' . ($this->payment_gateways['upfw']->capture === 'yes' ? 'false' : 'true') .
             '&amount=' . $money->getAmount() .
             '&currency=' . $money->getCurrency() .
-            '&metadata=' . json_encode($metatag) .
+            '&order_id=' . $order->get_id() .
             '&successRedirectUrl=' . urlencode($this->payment_gateways['upfw']->get_return_url($order)) .
             '&failureRedirectUrl=' . urlencode($this->payment_gateways['upfw']->get_return_url($order)) .
             '&pendingRedirectUrl=' . urlencode($this->payment_gateways['upfw']->get_return_url($order));

--- a/UnivaPay-for-WooCommerce/tests/test-payment-processing.php
+++ b/UnivaPay-for-WooCommerce/tests/test-payment-processing.php
@@ -2,8 +2,12 @@
 
 namespace Univapay\WooCommerce\Tests;
 
+use Mockery;
+use Mockery\MockInterface;
 use Money\Money;
 use Money\Currency;
+use Univapay\Resources\Authentication\AppJWT;
+use Univapay\UnivapayClient;
 
 class TestPaymentProcessing extends BasePluginTest
 {
@@ -31,52 +35,114 @@ class TestPaymentProcessing extends BasePluginTest
         $this->assertEquals($expectedRedirectUrl, $result['redirect'], 'Redirect URL does not match.');
     }
 
-    public function test_process_payment()
+    /**
+     * Initiates a mock charge
+     * @param WC_Order $order The order to be used in the mock charge.
+     * @return object The initiated mock charge.
+     */
+    private function initiate_mock_charge($order) : object
     {
-        // Scenario 1: no univapay charge token
+        return (object) [
+            'id' => $this->faker->uuid,
+            'metadata' => ['order_id' => $order->get_id()],
+            'transactionTokenId' => $this->faker->uuid,
+            'error' => false,
+        ];
+    }
+
+    /**
+     * Initiates a mock AppJWT.
+     * @return MockInterface The initiated mock AppJWT.
+     */
+    private function initiate_mock_app_jwt() : MockInterface
+    {
+        return Mockery::mock('alias:' . AppJWT::class)
+            ->shouldReceive('createToken')
+            ->andReturn((object) [
+                'storeId' => $this->faker->uuid
+            ])
+            ->getMock();
+    }
+
+    /**
+     * Initiates a mock client.
+     * @param object $mock_charge The mock charge to be returned by the client.
+     * @return MockInterface The initiated mock client.
+     */
+    private function initiate_mock_client($mock_charge) : MockInterface
+    {
+        $mock_payment_type = Mockery::mock();
+        $mock_payment_type->shouldReceive('getValue')->andReturn('card');
+
+        $mock_transaction_token = Mockery::mock();
+        $mock_transaction_token->paymentType = $mock_payment_type;
+
+        $mock_client = Mockery::mock(UnivapayClient::class);
+        $mock_client->shouldReceive('getCharge')->andReturn($mock_charge);
+        $mock_client->shouldReceive('getTransactionToken')->andReturn($mock_transaction_token);
+        
+        return $mock_client;
+    }
+
+    public function test_process_payment_validation()
+    {
         $this->payment_gateways['upfw']->capture = 'no';
         $_POST['univapay_optional'] = "false";
 
-        $order1 = $this->initiate_mock_order($this->initiate_mock_product());
-        $result1 = $this->payment_gateways['upfw']->process_payment($order1->get_id());
+        $mock_order1 = $this->initiate_mock_order($this->initiate_mock_product());
+        $result1 = $this->payment_gateways['upfw']->process_payment($mock_order1->get_id());
 
         $this->assertNull($result1);
         $error_messages = array_column(wc_get_notices('error'), 'notice');
         $this->assertContains('決済エラーサイト管理者にお問い合わせください。', $error_messages);
+    }
 
-        // Scenario 2: capture is 'no'
-        $this->payment_gateways['upfw']->capture = 'no';
+    public function order_completion_data_provider()
+    {
+        // Note: WooCommerce order status list
+        // pending, processing, on-hold, completed, cancelled, refunded, failed
+        return [
+            // Scenario 1: Capture is set to 'no', check base plugin test for the expected status
+            ['no', 'pending', 'UnivaPayでのオーソリが完了いたしました。'],
+            // Scenario 2: Capture is set to 'yes'
+            ['yes', 'processing', 'UnivaPayでの支払が完了いたしました。'],
+        ];
+    }
+
+    /**
+     * @dataProvider order_completion_data_provider
+     */
+    public function test_process_order_completion($capture, $expected_status, $expected_note)
+    {
+        $this->payment_gateways['upfw']->capture = $capture;
         $_POST['univapay_optional'] = "false";
-        $_POST['univapay_charge_id'] = $this->faker->word;
+        $mock_charge_token = $this->faker->word;
+        $_POST['univapay_charge_id'] = $mock_charge_token;
 
-        $order2 = $this->initiate_mock_order($this->initiate_mock_product());
-        $result2 = $this->payment_gateways['upfw']->process_payment($order2->get_id());
+        $mock_order = $this->initiate_mock_order($this->initiate_mock_product());
+        $result = $this->payment_gateways['upfw']->process_payment($mock_order->get_id());
 
-        $result_order2 = wc_get_order($order2->get_id());
-        $result_order2_notes = wc_get_order_notes(['order_id' => $order2->get_id()]);
+        $this->assertEquals('success', $result['result'], 'Payment processing did not return success.');
+        $this->assertStringContainsString('order-received=' . $mock_order->get_id(), $result['redirect'], 'Redirect URL does not contain order-received.');
+        $this->assertStringContainsString('key=' . $mock_order->get_order_key(), $result['redirect'], 'Redirect URL does not contain key.');
 
-        $this->assertEquals('success', $result2['result'], 'Payment processing did not return success.');
-        $this->assertStringContainsString('order-received=' . $order2->get_id(), $result2['redirect'], 'Redirect URL does not contain order-received.');
-        $this->assertStringContainsString('key=' . $order2->get_order_key(), $result2['redirect'], 'Redirect URL does not contain key.');
-        $this->assertEquals($this->payment_gateways['upfw']->status, $result_order2->get_status(), 'Order status does not match the expected status.');
-        $this->assertContains('UnivaPayでのオーソリが完了いたしました。', array_column($result_order2_notes, 'content'), 'Order note does not contain expected authorization message.');
+        // simulate the order completion process
+        WC()->session->set('order_awaiting_payment', $mock_order->get_id());
+        $_GET['univapayChargeId'] = $mock_charge_token;
+        global $wp;
+        $wp->query_vars['order-received'] = $mock_order->get_id();
+        $mock_charge = $this->initiate_mock_charge($mock_order);
+        $mock_client = $this->initiate_mock_client($mock_charge);
+        $mock_app_jwt = $this->initiate_mock_app_jwt();
+        $this->payment_gateways['upfw']->app_jwt = $mock_app_jwt;
+        $this->payment_gateways['upfw']->univapay_client = $mock_client;
+        $this->payment_gateways['upfw']->process_order_completion();
+        $result_order_notes = wc_get_order_notes(['order_id' => $mock_order->get_id()]);
 
-        // Scenario 3: capture is 'yes'
-        $this->payment_gateways['upfw']->capture = 'yes';
-        $_POST['univapay_optional'] = "false";
-        $_POST['univapay_charge_id'] = $this->faker->word;
-
-        $order3 = $this->initiate_mock_order($this->initiate_mock_product());
-        $result3 = $this->payment_gateways['upfw']->process_payment($order3->get_id());
-
-        $result_order3 = wc_get_order($order3->get_id());
-        $result_order3_notes = wc_get_order_notes(['order_id' => $order3->get_id()]);
-
-        $this->assertEquals('success', $result3['result'], 'Payment processing did not return success.');
-        $this->assertStringContainsString('order-received=' . $order3->get_id(), $result3['redirect'], 'Redirect URL does not contain order-received.');
-        $this->assertStringContainsString('key=' . $order3->get_order_key(), $result3['redirect'], 'Redirect URL does not contain key.');
-        // when capture is 'yes', the order status should be 'processing'
-        $this->assertEquals('processing', $result_order3->get_status(), 'Order status does not match the expected status.');
-        $this->assertContains('UnivaPayでの支払が完了いたしました。', array_column($result_order3_notes, 'content'), 'Order note does not contain expected payment completion message.');
+        $result_order = wc_get_order($mock_order->get_id());
+        $this->assertEquals($mock_charge->id, get_post_meta($result_order->get_id(), 'univapay_charge_id', true), 'Charge ID should be saved.');
+        $this->assertEquals($expected_status, $result_order->get_status(), 'Order status does not match the expected status.');
+        $this->assertContains($expected_note, array_column($result_order_notes, 'content'), 'Order note does not contain expected status change message.');
+        $this->assertEmpty(WC()->cart->get_cart(), 'Cart should be empty.');
     }
 }

--- a/UnivaPay-for-WooCommerce/tests/test-payment-processing.php
+++ b/UnivaPay-for-WooCommerce/tests/test-payment-processing.php
@@ -13,6 +13,9 @@ class TestPaymentProcessing extends BasePluginTest
         $_POST['univapay_optional'] = 'true';
         $result = $this->payment_gateways['upfw']->process_payment($order->get_id());
         $money = new Money($order->get_data()["total"], new Currency($order->get_data()["currency"]));
+        $metatag = array(
+            'order_id' => $order->get_id(),
+        );
 
         $expectedRedirectUrl = $this->payment_gateways['upfw']->formurl .
             '?appId=' . $this->payment_gateways['upfw']->token .
@@ -22,6 +25,7 @@ class TestPaymentProcessing extends BasePluginTest
             '&auth=' . ($this->payment_gateways['upfw']->capture === 'yes' ? 'false' : 'true') .
             '&amount=' . $money->getAmount() .
             '&currency=' . $money->getCurrency() .
+            '&metadata=' . json_encode($metatag) .
             '&successRedirectUrl=' . urlencode($this->payment_gateways['upfw']->get_return_url($order)) .
             '&failureRedirectUrl=' . urlencode($this->payment_gateways['upfw']->get_return_url($order)) .
             '&pendingRedirectUrl=' . urlencode($this->payment_gateways['upfw']->get_return_url($order));


### PR DESCRIPTION
Closes #8 

This pull request addresses the need for validation in the webhook and refactors the payment flow for better maintainability.

_Changes:_

Currently, the plugin supports 3 payment methods in WooCommerce:

- Inline Form Payment: The order is created after the payment is completed.
- Redirect or Widget Payment: The order is created first, and then updated after the payment is completed via a webhook.

Having multiple flows complicates the validation and maintenance of the plugin, 
_This PR unifies the payment process into a single flow:_

1. Create Temporary Order: An order is created and set to ["draft"](https://woocommerce.com/document/managing-orders/order-statuses/#draft-order-status) status.
2. User Completes Payment: The user completes the payment either via the Widget or Inline Form or Redirect method.
3. Update Order: The order status is updated based on the payment result.
